### PR TITLE
iOS 26 Support - Workaround to UIDropShadowView Presentation

### DIFF
--- a/Lynk/Components/ExtensionShareView.swift
+++ b/Lynk/Components/ExtensionShareView.swift
@@ -280,12 +280,13 @@ struct ExtensionShareView: View {
 				}
 				.padding([.horizontal, .top])
 				.background()
-				.clipShape(.rect(cornerRadii: RectangleCornerRadii(
-					topLeading: 12,
-					bottomLeading: 0,
-					bottomTrailing: 0,
-					topTrailing: 12
-				)))
+				// TODO: Find an alternative to adding top coners without affecting the safe area fill
+//				.clipShape(.rect(cornerRadii: RectangleCornerRadii(
+//					topLeading: 12,
+//					bottomLeading: 0,
+//					bottomTrailing: 0,
+//					topTrailing: 12
+//				)))
 			} else {
 				EmptyView()
 			}

--- a/LynkBookmark/ShareViewController.swift
+++ b/LynkBookmark/ShareViewController.swift
@@ -27,6 +27,21 @@ class ShareViewController: UIViewController {
 		setShareViewConstraints()
 	}
 	
+	// Using these 2 lifecycles to try counter the presentation of solid background UIDropShadowView
+	override func viewDidLayoutSubviews() {
+		super.viewDidLayoutSubviews()
+		if #available(iOS 26.0, *) {
+			removeDropShadowBackground(in: view)
+		}
+	}
+	
+	override func viewWillLayoutSubviews() {
+		super.viewWillLayoutSubviews()
+		if #available(iOS 26.0, *) {
+			removeDropShadowBackground(in: view)
+		}
+	}
+	
 	@objc func closeAction() {
 		self.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
 	}
@@ -42,4 +57,19 @@ class ShareViewController: UIViewController {
 			sharedItemView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
 		])
 	}
+	
+	// iOS 26 introduced a background shadow UIDropShadowView that prevented the usage of clear background
+	// This is the work around this issue
+	// Source: https://www.reddit.com/r/iOSProgramming/comments/1mj0et8/modal_presentation_in_uikit_adds_solid_background/
+	// Known issue: sometimes the white background is visible, can't figrure out how to completely remove it
+	private func removeDropShadowBackground(in view: UIView?) {
+		guard let view else { return }
+		if String(describing: type(of: view)).contains("UIDropShadowView") {
+			view.backgroundColor = .clear
+			view.isOpaque = false
+			return
+		}
+		removeDropShadowBackground(in: view.superview)
+	}
+
 }


### PR DESCRIPTION
## Description

In iOS 26, every presented sheet has a solid background due to `UIDropShadowView` and this was breaking the experience in share sheet.

The fix was to set it to clear and hope it never shows up.

In this PR, I also removed the clip shape on the share sheet to make sure the bottom sheet does go through the safe area

### After
| **iOS 17.2** | **iOS 26.0** |
| --- |  --- |
| <img width="300" alt="iPhone 15 Pro(17 2)" src="https://github.com/user-attachments/assets/24455759-4608-4c14-ab17-d2427190b3e5" /> | <img width="300" alt="iPhone 17 Pro" src="https://github.com/user-attachments/assets/9ff54fc1-5be1-43ae-b9ce-459d87d9a142" /> |

