### PR TITLE
Passcode implementation work

### DIFF
--- a/Lynk/Config/AppConfigs.xcconfig
+++ b/Lynk/Config/AppConfigs.xcconfig
@@ -1,0 +1,9 @@
+//
+//  AppConfigs.xcconfig
+//  Lynk
+//
+//  Created by Musoni nshuti Nicolas on 26/11/2025.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project

--- a/Lynk/ContentView.swift
+++ b/Lynk/ContentView.swift
@@ -38,18 +38,41 @@ struct ContentView: View {
 				AuthView(action: authenticate)
 			}
 		}
-		.alert(
-			biometricAuthError?.userInfo["NSLocalizedDescription"] as? String ?? "Biometric Authentication Failed",
-			isPresented: $showBiometricAuthErrorAlert,
-			presenting: biometricAuthError
-		) { _ in
-			Button("Settings") {
-				guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else { return }
-				openURL(settingsUrl)
+		.sheet(isPresented: $showBiometricAuthErrorAlert) {
+			VStack(alignment: .leading, spacing: 16) {
+				Text(biometricAuthError?.userInfo["NSLocalizedDescription"] as? String ?? "Biometric Authentication Failed")
+					.font(.title2)
+					.fontWeight(.semibold)
+					.lineLimit(2)
+				Text(biometricAuthError?.userInfo["NSDebugDescription"] as? String ?? "Failed to validate biometric authentication on this device. Please check your device settings and try again.")
+				VStack {
+					Button("Settings") {
+						guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else { return }
+						openURL(settingsUrl)
+						showBiometricAuthErrorAlert = false
+					}
+					.buttonStyle(.plain)
+					.padding()
+					.frame(maxWidth: .infinity)
+					.background(Color.blue)
+					.roundedBorder(for: .capsule)
+					.foregroundStyle(Color.white)
+					
+					Button("Cancel") {
+						showBiometricAuthErrorAlert = false
+					}
+					.buttonStyle(.plain)
+					.padding()
+					.frame(maxWidth: .infinity)
+					.background()
+					.roundedBorder(for: .capsule, color: .gray)
+					.foregroundStyle(Color.secondary)
+				}
 			}
-			Button("Cancel") { }
-		} message: { error in
-			Text(error?.userInfo["NSDebugDescription"] as? String ?? "Failed to validate biometric authentication on this device. Please check your device settings and try again.")
+			.frame(maxWidth: .infinity, alignment: .leading)
+			.padding()
+			.background()
+			.presentationDetents([.fraction(0.4)])
 		}
     }
 	

--- a/Lynk/Extensions/RoundedCorner.swift
+++ b/Lynk/Extensions/RoundedCorner.swift
@@ -21,6 +21,19 @@ extension View {
 			.background()
 			.clipShape(.rect(cornerRadius: radius))
 	}
+	
+	func roundedBorder<S>(
+		for shape: S,
+		color: Color = .gray.opacity(0.5),
+		lineWidth: CGFloat = 1
+	) -> some View where S: Shape {
+		self
+			.contentShape(shape)
+			.clipShape(shape)
+			.overlay {
+				shape.stroke(color, lineWidth: lineWidth)
+			}
+	}
 }
 
 #Preview {

--- a/Lynk/Models/AuthService.swift
+++ b/Lynk/Models/AuthService.swift
@@ -21,7 +21,7 @@ final class AuthService {
 		let context = LAContext()
 		var error: NSError?
 		return context.canEvaluatePolicy(
-			.deviceOwnerAuthenticationWithBiometrics,
+			.deviceOwnerAuthentication,
 			error: &error
 		)
 	}
@@ -33,7 +33,7 @@ final class AuthService {
 			throw AuthError.biometricsNotAvailable
 		}
 		return try await context.evaluatePolicy(
-			.deviceOwnerAuthenticationWithBiometrics,
+			.deviceOwnerAuthentication,
 			localizedReason: reason
 		)
 	}


### PR DESCRIPTION
### Description

Previously, when biometric authentication failed, then the user was locked out of the app.
This PR adds an option to authenticate with passcode

| **Auth View** | **Passcode** | **Error Alert** |
| --- | --- | --- |
| <img width="250" alt="IMG_8278" src="https://github.com/user-attachments/assets/8048b9f2-e951-4cd3-aba3-170b769071d3" /> | <img width="250" alt="IMG_8276" src="https://github.com/user-attachments/assets/e18189f8-47ab-4a78-93f7-d95fe304b540" /> | <img width="250" alt="IMG_8277" src="https://github.com/user-attachments/assets/8d488b05-af4d-4669-a84c-b50d6d0a0509" /> |





